### PR TITLE
fixed Pearson correlation coefficient formula

### DIFF
--- a/src/fastpcdtest.cpp
+++ b/src/fastpcdtest.cpp
@@ -52,7 +52,7 @@ corext quasi_correlation(NumericVector x, NumericVector y){
   validy = validy - my;
   // compute the rho
   double rho; // the result
-  rho = sqrt(static_cast<double>(T)) * sum(validx * validy) / sqrt(sum(pow(validx, 2)) * sum(pow(validy,2)));
+  rho = sqrt(static_cast<double>(T)) * sum(validx * validy) / sqrt(sum(pow(validx, 2))) * sqrt(sum(pow(validy,2)));
   // return the result
   corext result = {.correlation = rho, .common = T};;
   return(result);


### PR DESCRIPTION
 i believe there is a typo in the pcc formula in quasi_correlation function